### PR TITLE
fix new dish rating

### DIFF
--- a/models/Project.js
+++ b/models/Project.js
@@ -33,9 +33,11 @@ Project.init(
     },
     rating: {
       type: DataTypes.DECIMAL(3, 2),
+      defaultValue: 0,
     },
     actual_rating: {
       type: DataTypes.DECIMAL(5, 2),
+      defaultValue: 0,
     },
     rating_count: {
       type: DataTypes.INTEGER,


### PR DESCRIPTION
Added default values to rating and actual_rating, making it so you are able to rate new dishes that are created.